### PR TITLE
[STEP-5, STEP-6] 콘서트 예약 패키지 설계 및 Mock API 작성

### DIFF
--- a/src/main/kotlin/kr/hhplus/be/server/exception/ConflictException.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/exception/ConflictException.kt
@@ -1,0 +1,9 @@
+package kr.hhplus.be.server.exception
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+import java.lang.RuntimeException
+
+@ResponseStatus(HttpStatus.CONFLICT)
+class ConflictException: RuntimeException() {
+}

--- a/src/main/kotlin/kr/hhplus/be/server/exception/ForbiddenException.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/exception/ForbiddenException.kt
@@ -1,0 +1,9 @@
+package kr.hhplus.be.server.exception
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+import java.lang.RuntimeException
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
+class ForbiddenException: RuntimeException() {
+}

--- a/src/main/kotlin/kr/hhplus/be/server/exception/UnauthorizedException.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/exception/UnauthorizedException.kt
@@ -1,0 +1,9 @@
+package kr.hhplus.be.server.exception
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+import java.lang.RuntimeException
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+class UnauthorizedException: RuntimeException() {
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/config/jpa/JpaConfig.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/config/jpa/JpaConfig.kt
@@ -1,4 +1,4 @@
-package kr.hhplus.be.server.config.jpa
+package kr.hhplus.be.server.infrastructure.config.jpa
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -11,8 +11,8 @@ import org.springframework.transaction.PlatformTransactionManager
 @EnableJpaAuditing
 @EnableJpaRepositories
 class JpaConfig {
-    @Bean
-    fun transactionManager(): PlatformTransactionManager {
-        return JpaTransactionManager()
-    }
+	@Bean
+	fun transactionManager(): PlatformTransactionManager {
+		return JpaTransactionManager()
+	}
 }

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/concert/ConcertController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/concert/ConcertController.kt
@@ -1,9 +1,8 @@
 package kr.hhplus.be.server.interfaces.concert
 
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import kr.hhplus.be.server.exception.ForbiddenException
+import kr.hhplus.be.server.exception.UnauthorizedException
+import org.springframework.web.bind.annotation.*
 import java.time.ZonedDateTime
 
 @RestController
@@ -11,7 +10,13 @@ import java.time.ZonedDateTime
 class ConcertController {
 
     @GetMapping("")
-    fun getConcertInformation(): ConcertInformationResponse {
+    fun getConcertInformation(
+        @CookieValue("user-access-token") userAccessToken: String?,
+        @CookieValue("concert-access-token") concertAccessToken: String?
+    ): ConcertInformationResponse {
+        require(!userAccessToken.isNullOrBlank()) { throw UnauthorizedException() }
+        require(!concertAccessToken.isNullOrBlank()) { throw ForbiddenException() }
+
         return ConcertInformationResponse(
             mutableListOf(
                 ConcertInformationDto(1L, "아이유의 연말 콘서트", "아이유"),
@@ -21,7 +26,14 @@ class ConcertController {
     }
 
     @GetMapping("/{concertId}/schedules")
-    fun getConcertSchedules(@PathVariable concertId: String): ConcertScheduleResponse {
+    fun getConcertSchedules(
+        @CookieValue("user-access-token") userAccessToken: String?,
+        @CookieValue("concert-access-token") concertAccessToken: String?,
+        @PathVariable concertId: String
+    ): ConcertScheduleResponse {
+        require(!userAccessToken.isNullOrBlank()) { throw UnauthorizedException() }
+        require(!concertAccessToken.isNullOrBlank()) { throw ForbiddenException() }
+
         val now = ZonedDateTime.now()
         return ConcertScheduleResponse(
             mutableListOf(
@@ -33,9 +45,14 @@ class ConcertController {
 
     @GetMapping("/{concertId}/schedules/{scheduleId}/sections")
     fun getConcertSections(
+        @CookieValue("user-access-token") userAccessToken: String?,
+        @CookieValue("concert-access-token") concertAccessToken: String?,
         @PathVariable concertId: String,
         @PathVariable scheduleId: String
     ): ConcertSectionResponse {
+        require(!userAccessToken.isNullOrBlank()) { throw UnauthorizedException() }
+        require(!concertAccessToken.isNullOrBlank()) { throw ForbiddenException() }
+
         return ConcertSectionResponse(
             "항해 콘서트장",
             "서울특별시 항해구 항해로 123번길",
@@ -49,10 +66,15 @@ class ConcertController {
 
     @GetMapping("/{concertId}/schedules/{scheduleId}/sections/{sectionId}/seats")
     fun getConcertSeats(
+        @CookieValue("user-access-token") userAccessToken: String?,
+        @CookieValue("concert-access-token") concertAccessToken: String?,
         @PathVariable concertId: String,
         @PathVariable scheduleId: String,
         @PathVariable sectionId: String
     ): ConcertSeatResponse {
+        require(!userAccessToken.isNullOrBlank()) { throw UnauthorizedException() }
+        require(!concertAccessToken.isNullOrBlank()) { throw ForbiddenException() }
+
         return ConcertSeatResponse(
             mutableListOf(
                 ConcertSeatDto(1384L, 131, 150000),

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/concert/ConcertController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/concert/ConcertController.kt
@@ -9,77 +9,69 @@ import java.time.ZonedDateTime
 @RequestMapping("/concerts")
 class ConcertController {
 
-    @GetMapping("")
-    fun getConcertInformation(
-        @CookieValue("user-access-token") userAccessToken: String?,
-        @CookieValue("concert-access-token") concertAccessToken: String?
-    ): ConcertInformationResponse {
-        require(!userAccessToken.isNullOrBlank()) { throw UnauthorizedException() }
-        require(!concertAccessToken.isNullOrBlank()) { throw ForbiddenException() }
+	@GetMapping("")
+	fun getConcertInformation(
+		@CookieValue("user-access-token") userAccessToken: String?,
+		@CookieValue("concert-access-token") concertAccessToken: String?
+	): ConcertInformationResponse {
+		require(!userAccessToken.isNullOrBlank()) { throw UnauthorizedException() }
+		require(!concertAccessToken.isNullOrBlank()) { throw ForbiddenException() }
 
-        return ConcertInformationResponse(
-            mutableListOf(
-                ConcertInformationDto(1L, "아이유의 연말 콘서트", "아이유"),
-                ConcertInformationDto(2L, "아이유의 연초 콘서트", "아이유")
-            )
-        )
-    }
+		return ConcertInformationResponse(
+			mutableListOf(
+				ConcertInformationDto(1L, "아이유의 연말 콘서트", "아이유"),
+				ConcertInformationDto(2L, "아이유의 연초 콘서트", "아이유")
+			)
+		)
+	}
 
-    @GetMapping("/{concertId}/schedules")
-    fun getConcertSchedules(
-        @CookieValue("user-access-token") userAccessToken: String?,
-        @CookieValue("concert-access-token") concertAccessToken: String?,
-        @PathVariable concertId: String
-    ): ConcertScheduleResponse {
-        require(!userAccessToken.isNullOrBlank()) { throw UnauthorizedException() }
-        require(!concertAccessToken.isNullOrBlank()) { throw ForbiddenException() }
+	@GetMapping("/{concertId}/schedules")
+	fun getConcertSchedules(
+		@CookieValue("user-access-token") userAccessToken: String?,
+		@CookieValue("concert-access-token") concertAccessToken: String?,
+		@PathVariable concertId: String
+	): ConcertScheduleResponse {
+		require(!userAccessToken.isNullOrBlank()) { throw UnauthorizedException() }
+		require(!concertAccessToken.isNullOrBlank()) { throw ForbiddenException() }
 
-        val now = ZonedDateTime.now()
-        return ConcertScheduleResponse(
-            mutableListOf(
-                ConcertScheduleDto(123L, now, now.plusHours(3)),
-                ConcertScheduleDto(124L, now.plusDays(1), now.plusHours(27))
-            )
-        )
-    }
+		val now = ZonedDateTime.now()
+		return ConcertScheduleResponse(
+			mutableListOf(
+				ConcertScheduleDto(
+					123L,
+					"콘서트장1",
+					"서울특별시 항해구 항해로 123번길",
+					50,
+					now,
+					now.plusHours(3)
+				),
+				ConcertScheduleDto(
+					124L,
+					"콘서트장2",
+					"서울특별시 항해구 항해로 124번길",
+					50,
+					now.plusDays(1),
+					now.plusHours(27)
+				)
+			)
+		)
+	}
 
-    @GetMapping("/{concertId}/schedules/{scheduleId}/sections")
-    fun getConcertSections(
-        @CookieValue("user-access-token") userAccessToken: String?,
-        @CookieValue("concert-access-token") concertAccessToken: String?,
-        @PathVariable concertId: String,
-        @PathVariable scheduleId: String
-    ): ConcertSectionResponse {
-        require(!userAccessToken.isNullOrBlank()) { throw UnauthorizedException() }
-        require(!concertAccessToken.isNullOrBlank()) { throw ForbiddenException() }
+	@GetMapping("/{concertId}/schedules/{scheduleId}/seats")
+	fun getConcertSeats(
+		@CookieValue("user-access-token") userAccessToken: String?,
+		@CookieValue("concert-access-token") concertAccessToken: String?,
+		@PathVariable concertId: String,
+		@PathVariable scheduleId: String
+	): ConcertSeatResponse {
+		require(!userAccessToken.isNullOrBlank()) { throw UnauthorizedException() }
+		require(!concertAccessToken.isNullOrBlank()) { throw ForbiddenException() }
 
-        return ConcertSectionResponse(
-            "항해 콘서트장",
-            "서울특별시 항해구 항해로 123번길",
-            10000,
-            mutableListOf(
-                ConcertSectionDto(249L, "스탠딩석 A", 100, 83),
-                ConcertSectionDto(250L, "스탠딩석 B", 100, 100),
-            )
-        )
-    }
-
-    @GetMapping("/{concertId}/schedules/{scheduleId}/sections/{sectionId}/seats")
-    fun getConcertSeats(
-        @CookieValue("user-access-token") userAccessToken: String?,
-        @CookieValue("concert-access-token") concertAccessToken: String?,
-        @PathVariable concertId: String,
-        @PathVariable scheduleId: String,
-        @PathVariable sectionId: String
-    ): ConcertSeatResponse {
-        require(!userAccessToken.isNullOrBlank()) { throw UnauthorizedException() }
-        require(!concertAccessToken.isNullOrBlank()) { throw ForbiddenException() }
-
-        return ConcertSeatResponse(
-            mutableListOf(
-                ConcertSeatDto(1384L, 131, 150000),
-                ConcertSeatDto(1385L, 132, 150000),
-            )
-        )
-    }
+		return ConcertSeatResponse(
+			mutableListOf(
+				ConcertSeatDto(1384L, 131, 150000),
+				ConcertSeatDto(1385L, 132, 150000),
+			)
+		)
+	}
 }

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/concert/ConcertController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/concert/ConcertController.kt
@@ -1,0 +1,63 @@
+package kr.hhplus.be.server.interfaces.concert
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.ZonedDateTime
+
+@RestController
+@RequestMapping("/concerts")
+class ConcertController {
+
+    @GetMapping("")
+    fun getConcertInformation(): ConcertInformationResponse {
+        return ConcertInformationResponse(
+            mutableListOf(
+                ConcertInformationDto(1L, "아이유의 연말 콘서트", "아이유"),
+                ConcertInformationDto(2L, "아이유의 연초 콘서트", "아이유")
+            )
+        )
+    }
+
+    @GetMapping("/{concertId}/schedules")
+    fun getConcertSchedules(@PathVariable concertId: String): ConcertScheduleResponse {
+        val now = ZonedDateTime.now()
+        return ConcertScheduleResponse(
+            mutableListOf(
+                ConcertScheduleDto(123L, now, now.plusHours(3)),
+                ConcertScheduleDto(124L, now.plusDays(1), now.plusHours(27))
+            )
+        )
+    }
+
+    @GetMapping("/{concertId}/schedules/{scheduleId}/sections")
+    fun getConcertSections(
+        @PathVariable concertId: String,
+        @PathVariable scheduleId: String
+    ): ConcertSectionResponse {
+        return ConcertSectionResponse(
+            "항해 콘서트장",
+            "서울특별시 항해구 항해로 123번길",
+            10000,
+            mutableListOf(
+                ConcertSectionDto(249L, "스탠딩석 A", 100, 83),
+                ConcertSectionDto(250L, "스탠딩석 B", 100, 100),
+            )
+        )
+    }
+
+    @GetMapping("/{concertId}/schedules/{scheduleId}/sections/{sectionId}/seats")
+    fun getConcertSeats(
+        @PathVariable concertId: String,
+        @PathVariable scheduleId: String,
+        @PathVariable sectionId: String
+    ): ConcertSeatResponse {
+        return ConcertSeatResponse(
+            mutableListOf(
+                ConcertSeatDto(1384L, 131, 150000),
+                ConcertSeatDto(1385L, 132, 150000),
+            )
+        )
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/concert/ConcertInformationResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/concert/ConcertInformationResponse.kt
@@ -1,0 +1,11 @@
+package kr.hhplus.be.server.interfaces.concert
+
+data class ConcertInformationResponse(
+    val concerts: MutableList<ConcertInformationDto>
+)
+
+data class ConcertInformationDto(
+    val concertId: Long,
+    val title: String,
+    val provider: String
+)

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/concert/ConcertScheduleResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/concert/ConcertScheduleResponse.kt
@@ -8,6 +8,9 @@ data class ConcertScheduleResponse(
 
 data class ConcertScheduleDto(
     val concertScheduleId: Long,
+    val concertPlace: String,
+    val concertLocation: String,
+    val totalSeat: Int,
     val startAt: ZonedDateTime,
     val endAt: ZonedDateTime
 )

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/concert/ConcertScheduleResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/concert/ConcertScheduleResponse.kt
@@ -1,0 +1,13 @@
+package kr.hhplus.be.server.interfaces.concert
+
+import java.time.ZonedDateTime
+
+data class ConcertScheduleResponse(
+    val concertSchedules: MutableList<ConcertScheduleDto>
+)
+
+data class ConcertScheduleDto(
+    val concertScheduleId: Long,
+    val startAt: ZonedDateTime,
+    val endAt: ZonedDateTime
+)

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/concert/ConcertSeatResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/concert/ConcertSeatResponse.kt
@@ -1,0 +1,13 @@
+package kr.hhplus.be.server.interfaces.concert
+
+import java.time.ZonedDateTime
+
+data class ConcertSeatResponse(
+    val concertSchedules: MutableList<ConcertSeatDto>
+)
+
+data class ConcertSeatDto(
+    val seatId: Long,
+    val seatNumber: Int,
+    val price: Int
+)

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/concert/ConcertSectionResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/concert/ConcertSectionResponse.kt
@@ -1,0 +1,17 @@
+package kr.hhplus.be.server.interfaces.concert
+
+import java.time.ZonedDateTime
+
+data class ConcertSectionResponse(
+    val concertPlaceName: String,
+    val concertPosition: String,
+    val totalSeat: Int,
+    val sections: MutableList<ConcertSectionDto>
+)
+
+data class ConcertSectionDto(
+    val concertSectionId: Long,
+    val sectionName: String,
+    val totalSeat: Int,
+    val remainSeat: Int
+)

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/payment/PayRequest.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/payment/PayRequest.kt
@@ -1,0 +1,5 @@
+package kr.hhplus.be.server.interfaces.payment
+
+data class PayRequest(
+    val reservationIds: List<Int>
+)

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/payment/PaymentController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/payment/PaymentController.kt
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.interfaces.payment
+
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/payments")
+class PaymentController {
+
+    @PostMapping("")
+    fun pay(payRequest: PayRequest) {
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/payment/PaymentController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/payment/PaymentController.kt
@@ -1,14 +1,22 @@
 package kr.hhplus.be.server.interfaces.payment
 
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import kr.hhplus.be.server.exception.ForbiddenException
+import kr.hhplus.be.server.exception.UnauthorizedException
+import org.apache.coyote.BadRequestException
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.client.HttpClientErrorException.Forbidden
 
 @RestController
 @RequestMapping("/payments")
 class PaymentController {
 
     @PostMapping("")
-    fun pay(payRequest: PayRequest) {
+    fun pay(
+        @CookieValue("user-access-token") userAccessToken: String?,
+        @RequestBody payRequest: PayRequest
+    ) {
+        require(!payRequest.reservationIds.contains(0)) { throw BadRequestException() }
+        require(!userAccessToken.isNullOrBlank()) { throw UnauthorizedException() }
+        require(!payRequest.reservationIds.contains(-1)) { throw ForbiddenException() }
     }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/queue/QueueController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/queue/QueueController.kt
@@ -1,0 +1,29 @@
+package kr.hhplus.be.server.interfaces.queue
+
+import org.springframework.http.HttpHeaders.SET_COOKIE
+import org.springframework.http.ResponseCookie
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/tokens")
+class QueueController {
+
+    @PostMapping("")
+    fun publishQueueToken(): ResponseEntity<Unit> {
+        return ResponseEntity.ok()
+            .header(
+                SET_COOKIE,
+                ResponseCookie.from("concert-access-token", "DH8FF4NKJD082").build().toString()
+            )
+            .body(Unit)
+    }
+
+    @GetMapping("")
+    fun getWaitingInformation(): WaitingInformationResponse {
+        return WaitingInformationResponse(381297L, 25)
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/queue/QueueController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/queue/QueueController.kt
@@ -1,20 +1,24 @@
 package kr.hhplus.be.server.interfaces.queue
 
+import kr.hhplus.be.server.exception.ForbiddenException
+import kr.hhplus.be.server.exception.UnauthorizedException
 import org.springframework.http.HttpHeaders.SET_COOKIE
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseCookie
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/tokens")
 class QueueController {
 
     @PostMapping("")
-    fun publishQueueToken(): ResponseEntity<Unit> {
-        return ResponseEntity.ok()
+    fun publishQueueToken(
+        @CookieValue("user-access-token") userAccessToken: String?
+    ): ResponseEntity<Unit> {
+        require(!userAccessToken.isNullOrBlank()) { throw UnauthorizedException() }
+
+        return ResponseEntity.status(HttpStatus.CREATED)
             .header(
                 SET_COOKIE,
                 ResponseCookie.from("concert-access-token", "DH8FF4NKJD082").build().toString()
@@ -23,7 +27,13 @@ class QueueController {
     }
 
     @GetMapping("")
-    fun getWaitingInformation(): WaitingInformationResponse {
+    fun getWaitingInformation(
+        @CookieValue("user-access-token") userAccessToken: String?,
+        @CookieValue("concert-access-token") concertAccessToken: String?
+    ): WaitingInformationResponse {
+        require(!userAccessToken.isNullOrBlank()) { throw UnauthorizedException() }
+        require(!concertAccessToken.isNullOrBlank()) { throw ForbiddenException() }
+
         return WaitingInformationResponse(381297L, 25)
     }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/queue/WaitingInformationResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/queue/WaitingInformationResponse.kt
@@ -1,0 +1,6 @@
+package kr.hhplus.be.server.interfaces.queue
+
+data class WaitingInformationResponse(
+    val myOrder: Long,
+    val waitingMinutes: Int
+)

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/reservation/ReservationController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/reservation/ReservationController.kt
@@ -1,0 +1,19 @@
+package kr.hhplus.be.server.interfaces.reservation
+
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.ZonedDateTime
+
+@RestController
+@RequestMapping("/reservations")
+class ReservationController {
+
+    @PostMapping("")
+    fun reserveConcertSeat(
+        @RequestBody reserveConcertRequest: ReserveConcertRequest
+    ): ReserveConcertResponse {
+        return ReserveConcertResponse(438L, ZonedDateTime.now().plusDays(3))
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/reservation/ReservationController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/reservation/ReservationController.kt
@@ -1,9 +1,10 @@
 package kr.hhplus.be.server.interfaces.reservation
 
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import kr.hhplus.be.server.exception.ConflictException
+import kr.hhplus.be.server.exception.ForbiddenException
+import kr.hhplus.be.server.exception.UnauthorizedException
+import org.apache.coyote.BadRequestException
+import org.springframework.web.bind.annotation.*
 import java.time.ZonedDateTime
 
 @RestController
@@ -12,8 +13,15 @@ class ReservationController {
 
     @PostMapping("")
     fun reserveConcertSeat(
+        @CookieValue("user-access-token") userAccessToken: String?,
+        @CookieValue("concert-access-token") concertAccessToken: String?,
         @RequestBody reserveConcertRequest: ReserveConcertRequest
     ): ReserveConcertResponse {
+        require(reserveConcertRequest.concertId != 0L) { throw BadRequestException() }
+        require(!userAccessToken.isNullOrBlank()) { throw UnauthorizedException() }
+        require(!concertAccessToken.isNullOrBlank()) { throw ForbiddenException() }
+        require(reserveConcertRequest.concertId != -1L) { throw ConflictException() }
+
         return ReserveConcertResponse(438L, ZonedDateTime.now().plusDays(3))
     }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/reservation/ReserveConcertRequest.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/reservation/ReserveConcertRequest.kt
@@ -1,0 +1,8 @@
+package kr.hhplus.be.server.interfaces.reservation
+
+data class ReserveConcertRequest(
+    val concertId: Long,
+    val concertScheduleId: Long,
+    val concertSectionId: Long,
+    val concertSeatId: Long
+)

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/reservation/ReserveConcertResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/reservation/ReserveConcertResponse.kt
@@ -1,0 +1,8 @@
+package kr.hhplus.be.server.interfaces.reservation
+
+import java.time.ZonedDateTime
+
+data class ReserveConcertResponse(
+    val reservationId: Long,
+    val reservationExpiredAt: ZonedDateTime
+)

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/user/ChargePointRequest.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/user/ChargePointRequest.kt
@@ -1,0 +1,5 @@
+package kr.hhplus.be.server.interfaces.user
+
+data class ChargePointRequest(
+    val chargePoint: Int
+)

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/user/RemainPointResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/user/RemainPointResponse.kt
@@ -1,0 +1,5 @@
+package kr.hhplus.be.server.interfaces.user
+
+data class RemainPointResponse(
+    val remainPoint: Int
+)

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/user/UserController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/user/UserController.kt
@@ -1,0 +1,30 @@
+package kr.hhplus.be.server.interfaces.user
+
+import org.springframework.http.HttpHeaders.SET_COOKIE
+import org.springframework.http.ResponseCookie
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/users")
+class UserController {
+
+    @PostMapping("/{userId}")
+    fun publishUserToken(@PathVariable userId: Long) : ResponseEntity<Unit> {
+        return ResponseEntity.ok()
+            .header(
+                SET_COOKIE,
+                ResponseCookie.from("user-access-token", "EI9137BFKJD98").build().toString()
+            )
+            .body(Unit)
+    }
+
+    @GetMapping("/points")
+    fun getRemainPoint(): RemainPointResponse {
+        return RemainPointResponse(20000)
+    }
+
+    @PostMapping("/points")
+    fun chargePoint(chargePointRequest: ChargePointRequest) {
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/user/UserController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/user/UserController.kt
@@ -1,9 +1,13 @@
 package kr.hhplus.be.server.interfaces.user
 
+import kr.hhplus.be.server.exception.UnauthorizedException
+import org.apache.coyote.BadRequestException
 import org.springframework.http.HttpHeaders.SET_COOKIE
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseCookie
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import org.springframework.web.client.HttpClientErrorException.Unauthorized
 
 @RestController
 @RequestMapping("/users")
@@ -11,7 +15,9 @@ class UserController {
 
     @PostMapping("/{userId}")
     fun publishUserToken(@PathVariable userId: Long) : ResponseEntity<Unit> {
-        return ResponseEntity.ok()
+        require(userId != 0L) { throw BadRequestException() }
+
+        return ResponseEntity.status(HttpStatus.CREATED)
             .header(
                 SET_COOKIE,
                 ResponseCookie.from("user-access-token", "EI9137BFKJD98").build().toString()
@@ -20,11 +26,19 @@ class UserController {
     }
 
     @GetMapping("/points")
-    fun getRemainPoint(): RemainPointResponse {
+    fun getRemainPoint(
+        @CookieValue("user-access-token") userAccessToken: String?
+    ): RemainPointResponse {
+        require(!userAccessToken.isNullOrBlank()) { throw UnauthorizedException() }
+
         return RemainPointResponse(20000)
     }
 
     @PostMapping("/points")
-    fun chargePoint(chargePointRequest: ChargePointRequest) {
+    fun chargePoint(
+        @CookieValue("user-access-token") userAccessToken: String?,
+        @RequestBody chargePointRequest: ChargePointRequest
+    ) {
+        require(!userAccessToken.isNullOrBlank()) { throw UnauthorizedException() }
     }
 }


### PR DESCRIPTION
## PR 설명

도메인들의 패키지 구조를 설계하고, Mock API를 작성하였습니다.


## 리뷰 포인트
- 결제 로직에서 트랜잭션 단위를 짧게 가져가고 싶어서, 각 도메인별로 트랜잭션을 묶고 실패 시 보상 트랜잭션을 적용하는 방식으로 시퀀스 다이어그램을 작성했습니다. 우려되는 사항이나 문제가 될 여지가 있을까요?
- 서버에 진입하는 토큰의 수를 대략적으로 계산해보았는데, 처음 계산하다보니 이렇게 계산하는게 맞나 의문이 듭니다. 검토 부탁드리겠습니다.
  - 요청별 Read/Write 수
    - 대부분 조회 로직 : read 2~3개
    - 잔액 충전 : read 2개 / write 1개
    - 예약 : read 4개 / write 1개
    - 결제 : read 4개 / write 1개
  - 처리시간 계산(read 2ms / write 10ms 가정)
    - 대부분 조회 로직 : 5ms 내외
    - 잔액 충전 : 14ms
    - 예약 : 18ms
    - 결제 : 18ms
  - 요청당 평균 처리 시간 : 8ms (조회 7.5 / 충전 0.5 / 예약 1 / 결제 1 비율로 가정하여 계산)
  - TPS : 1000 / 8 = 125 TPS
  - 성능의 70%를 최대치로 둔다고 하면, 초당 85개의 요청을 처리 
  - **대략 5초에 400개씩 토큰을 진입**


## Definition of Done (DoD)
- [x] Milestone 작성 완료 ([3주차 - 콘서트 예약 마일스톤](https://thinkable-son-6b5.notion.site/3-Milestone-16f01bed19ff80b1aa1de4e5b42c61b7?pvs=4))
- [x] 요구사항 분석 완료 ([3주차 - 콘서트 예약 요구사항 분석자료](https://thinkable-son-6b5.notion.site/3-16c01bed19ff8060879ad22c3efad6d3?pvs=4))
- [x] ERD 설계 완료 ([3주차 - 콘서트 예약 엔티티 및 ERD 설계](https://thinkable-son-6b5.notion.site/3-ERD-16f01bed19ff80f5a545cba81fb8c8dd?pvs=4))
- [x] API 명세 완료 ([3주차 - 콘서트 예약 API Specification](https://thinkable-son-6b5.notion.site/3-API-16f01bed19ff806988d7dc2a1dae9f42?pvs=4))
